### PR TITLE
remove outdated info from docstring

### DIFF
--- a/src/maison/utils.py
+++ b/src/maison/utils.py
@@ -74,8 +74,7 @@ def _collect_configs(
     Args:
         project_name: the name of the project to be used to find the right section in
             the config file
-        source_files: a list of source config filenames to look for. The first one found
-            will be selected
+        source_files: a list of source config filenames to look for.
         starting_path: an optional starting path to start the search
 
     Returns:


### PR DESCRIPTION
Maison now supports multiple config files. This PR removes some outdated info from a docstring.