### PR TITLE
print filename if toml loading fails

### DIFF
--- a/src/maison/config_sources/toml_source.py
+++ b/src/maison/config_sources/toml_source.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 import toml
 
+from ..errors import BadTomlError
 from .base_source import BaseSource
 
 
@@ -25,5 +26,13 @@ class TomlSource(BaseSource):
 
         Returns:
             the `.toml` source converted to a `dict`
+
+        Raises:
+            BadTomlError: If toml cannot be parsed
         """
-        return dict(toml.load(self.filepath))
+        try:
+            return dict(toml.load(self.filepath))
+        except toml.decoder.TomlDecodeError as exc:
+            raise BadTomlError(
+                f"Error trying to load toml file '{self.filepath}'"
+            ) from exc

--- a/src/maison/config_sources/toml_source.py
+++ b/src/maison/config_sources/toml_source.py
@@ -32,7 +32,7 @@ class TomlSource(BaseSource):
         """
         try:
             return dict(toml.load(self.filepath))
-        except toml.decoder.TomlDecodeError as exc:
+        except toml.decoder.TomlDecodeError as exc:  # type: ignore
             raise BadTomlError(
                 f"Error trying to load toml file '{self.filepath}'"
             ) from exc

--- a/src/maison/errors.py
+++ b/src/maison/errors.py
@@ -3,3 +3,7 @@
 
 class NoSchemaError(Exception):
     """Raised when validation is attempted but no schema has been provided."""
+
+
+class BadTomlError(Exception):
+    """Raised when loading from an invalid toml source is attempted."""


### PR DESCRIPTION
This PR adds a try/catch block around the call to `toml.load` in the implementation of `TomlSource`, allowing us to print the name of the offending file in case of a toml parsing error.

Closes #92.