### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,17 @@ Suppose the following `pyproject.toml` lives somewhere in a project directory:
 enable_useful_option = true
 ```
 
-`maison` exposes a `ProjectConfig` class to retrieve values from config files
+`maison` exposes a `UserConfig` class to retrieve values from config files
 like so:
 
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
 from my_useful_package import run_useful_action
 
-config = ProjectConfig(project_name="acme")
+config = UserConfig(project_name="acme")
 
-if config.get_option("enable_useful_option"):
+if config.values["enable_useful_option"]:
     run_useful_action()
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Read configuration settings from configuration files.
 
 ## Motivation
 
-When developing a `python` package, e.g a command-line tool, it can be
-helpful to allow the user to set their own configuration options to allow them
-to tailor the tool to their needs. These options are typically set in files in
-the root of a project directory that uses the tool, for example in a
-`pyproject.toml` or an `{project_name}.ini` file.
+When developing a `python` package, e.g a command-line tool, it can be helpful
+to allow the user to set their own configuration options to allow them to tailor
+the tool to their needs. These options are typically set in files in the root of
+a user's directory that uses the tool, for example in a `pyproject.toml` or an
+`{project_name}.ini` file.
 
 `maison` aims to provide a simple and flexible way to read and validate those
 configuration options so that they may be used in the package.
@@ -34,7 +34,7 @@ pip install maison
 
 ## Usage
 
-Suppose the following `pyproject.toml` lives somewhere in a project directory:
+Suppose the following `pyproject.toml` lives somewhere in a user's directory:
 
 ```toml
 [tool.acme]
@@ -49,7 +49,7 @@ from maison import UserConfig
 
 from my_useful_package import run_useful_action
 
-config = UserConfig(project_name="acme")
+config = UserConfig(package_name="acme")
 
 if config.values["enable_useful_option"]:
     run_useful_action()

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,10 +3,8 @@
 ## Main API
 
 ```{eval-rst}
-.. automodule:: maison.ProjectConfig
+.. autoclass:: maison.ProjectConfig
    :members:
-   :imported-members:
-   :special-members: __init__
 ```
 
 ## Exceptions

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -3,7 +3,7 @@
 ## Main API
 
 ```{eval-rst}
-.. autoclass:: maison.ProjectConfig
+.. autoclass:: maison.UserConfig
    :members:
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ allows config values to be retrieved:
 
 ```python
 >>> from maison import UserConfig
->>> config = UserConfig(project_name="acme")
+>>> config = UserConfig(package_name="acme")
 >>> config.values
 "{'foo': 'bar'}"
 >>> config.values["foo"]
@@ -35,7 +35,7 @@ first source file it finds from the list.
 from maison import UserConfig
 
 config = UserConfig(
-  project_name="acme",
+  package_name="acme",
   source_files=["acme.ini", "pyproject.toml"]
 )
 
@@ -47,7 +47,7 @@ print(config.path)
 Currently only `.toml` and `.ini` files are supported. For `.ini` files,
 `maison` assumes that the whole file is relevant. For `pyproject.toml` files,
 `maison` assumes that the relevant section will be in a
-`[tool.{project_name}]` section. For other `.toml` files `maison` assumes the whole
+`[tool.{package_name}]` section. For other `.toml` files `maison` assumes the whole
 file is relevant.
 ```
 
@@ -65,7 +65,7 @@ The source file can either be a filename or an absolute path to a config:
 from maison import UserConfig
 
 config = UserConfig(
-  project_name="acme",
+  package_name="acme",
   source_files=["~/.config/acme.ini", "pyproject.toml"]
 )
 
@@ -82,7 +82,7 @@ flag to `True` in the constructor for `UserConfig`:
 from maison import UserConfig
 
 config = UserConfig(
-  project_name="acme",
+  package_name="acme",
   source_files=["~/.config/acme.toml", "~/.acme.ini", "pyproject.toml"],
   merge_configs=True
 )
@@ -119,7 +119,7 @@ You can start searching from a different path by providing a `starting_path` pro
 from maison import UserConfig
 
 config = UserConfig(
-  project_name="acme",
+  package_name="acme",
   starting_path=Path("/some/other/path")
 )
 
@@ -154,7 +154,7 @@ Then inject the schema when instantiating a `UserConfig`:
 ```python
 from maison import UserConfig
 
-config = UserConfig(project_name="acme", schema=MySchema)
+config = UserConfig(package_name="acme", schema=MySchema)
 ```
 
 To validate the config, simply run `validate()` on the config instance:
@@ -195,7 +195,7 @@ class MySchema(BaseModel):
 Running the config through validation will render the following:
 
 ```python
-config = UserConfig(project_name="acme", schema=MySchema)
+config = UserConfig(package_name="acme", schema=MySchema)
 
 print(config)
 #> {"foo": 1}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,12 +2,6 @@
 
 ## Retrieving values
 
-<!-- ```{eval-rst} -->
-<!-- .. click:: maison.__main__:main -->
-<!--     :prog: maison -->
-<!--     :nested: full -->
-<!-- ``` -->
-
 Once an instance of `ProjectConfig` has been created, values can be retrieved through:
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,94 +1,93 @@
 # Usage
 
+Suppose a `pyproject.toml` file lives in the user's directory:
+
+```toml
+[tool.acme]
+foo = "bar"
+```
+
 ## Retrieving values
 
-Once an instance of `ProjectConfig` has been created, values can be retrieved through:
+`UserConfig` objects have a `values` property that behaves as a dict which
+allows config values to be retrieved:
 
 ```python
->>> config.get_option("foo")
+>>> from maison import UserConfig
+>>> config = UserConfig(project_name="acme")
+>>> config.values
+"{'foo': 'bar'}"
+>>> config.values["foo"]
 'bar'
-```
-
-An optional second argument can be provided to `get_option` which will be returned if
-the given option isn't found:
-
-```python
->>> config.get_option("baz", "default")
-'default'
-```
-
-`ProjectConfig` also exposes a `to_dict()` method to return all the config
-options:
-
-```python
->>> config.to_dict()
-{'foo': 'bar'}
+>>> "baz" in config.values
+False
+>>> config.values.get("baz", "qux")
+'qux'
 ```
 
 ## Source files
 
 By default, `maison` will look for a `pyproject.toml` file. If you prefer to look
-elsewhere, provide a `source_files` list to `ProjectConfig` and `maison` will select the
+elsewhere, provide a `source_files` list to `UserConfig` and `maison` will select the
 first source file it finds from the list.
 
-
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
-config = ProjectConfig(
+config = UserConfig(
   project_name="acme",
   source_files=["acme.ini", "pyproject.toml"]
 )
 
-print(config.config_path)
+print(config.path)
 #> PosixPath(/path/to/acme.ini)
 ```
 
 ```{caution}
-    Currently only `.toml` and `.ini` files are supported. For `.ini` files,
-    `maison` assumes that the whole file is relevant. For `pyproject.toml` files,
-    `maison` assumes that the relevant section will be in a
-    `[tool.{project_name}]` section. For other `.toml` files `maison` assumes the whole
-    file is relevant.
+Currently only `.toml` and `.ini` files are supported. For `.ini` files,
+`maison` assumes that the whole file is relevant. For `pyproject.toml` files,
+`maison` assumes that the relevant section will be in a
+`[tool.{project_name}]` section. For other `.toml` files `maison` assumes the whole
+file is relevant.
 ```
 
-To verify which source config file has been found, `ProjectConfig` exposes a
-`config_path` property:
+To verify which source config file has been found, `UserConfig` exposes a
+`path` property:
 
 ```python
->>> config.config_path
+>>> config.path
 PosixPath('/path/to/pyproject.toml')
 ```
 
 The source file can either be a filename or an absolute path to a config:
 
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
-config = ProjectConfig(
+config = UserConfig(
   project_name="acme",
   source_files=["~/.config/acme.ini", "pyproject.toml"]
 )
 
-print(config.config_path)
+print(config.path)
 #> PosixPath(/Users/tom.jones/.config/acme.ini)
 ```
 
 ## Merging configs
 
 `maison` offers support for merging multiple configs. To do so, set the `merge_configs`
-flag to `True` in the constructor for `ProjectConfig`:
+flag to `True` in the constructor for `UserConfig`:
 
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
-config = ProjectConfig(
+config = UserConfig(
   project_name="acme",
   source_files=["~/.config/acme.toml", "~/.acme.ini", "pyproject.toml"],
   merge_configs=True
 )
 
-print(config.config_path)
+print(config.path)
 """
 [
   PosixPath(/Users/tom.jones/.config/acme.toml),
@@ -102,10 +101,10 @@ print(config.get_option("foo"))
 ```
 
 ```{warning}
-    When merging configs, `maison` merges from **right to left**, ie. rightmost sources
-    take precedence. So in the above example, if `~/config/.acme.toml` and
-    `pyproject.toml` both set `nice_option`, the value from `pyproject.toml` will be
-    returned from `config.get_option("nice_option")`.
+When merging configs, `maison` merges from **right to left**, ie. rightmost sources
+take precedence. So in the above example, if `~/config/.acme.toml` and
+`pyproject.toml` both set `nice_option`, the value from `pyproject.toml` will be
+returned from `config.get_option("nice_option")`.
 ```
 
 ## Search paths
@@ -114,42 +113,48 @@ By default, `maison` searches for config files by starting at `Path.cwd()` and m
 the tree until it finds the relevant config file or there are no more parent paths.
 
 You can start searching from a different path by providing a `starting_path` property to
-`ProjectConfig`:
+`UserConfig`:
 
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
-config = ProjectConfig(
+config = UserConfig(
   project_name="acme",
   starting_path=Path("/some/other/path")
 )
 
-print(config.config_path)
+print(config.path)
 #> PosixPath(/some/other/path/pyproject.toml)
 ```
 
 ## Validation
 
-`maison` offers optional schema validation using [pydantic](https://pydantic-docs.helpmanual.io/).
+`maison` offers optional schema validation.
 
-To validate a configuration, first create a schema which subclasses `ConfigSchema`:
+To validate a configuration, first create a schema. The schema should implement
+a method called `dict`. This can be achieved by writing the schema as a
+`pydantic` model:
 
 ```python
-from maison import ConfigSchema
+from pydantic import BaseModel
 
-class MySchema(ConfigSchema):
+class MySchema(BaseModel):
   foo: str = "my_default"
 ```
 
-!!! note ""
-    `ConfigSchema` offers all the same functionality as the `pydantic` [BaseModel](https://pydantic-docs.helpmanual.io/usage/models/)
+```{note}
+`maison` validation was built with using `pydantic` models as schemas in mind
+but this package doesn't explicitly declare `pydantic` as a dependency so you
+are free to use another validation package if you wish, you just need to ensure
+that your schema follows the `maison.config._IsSchema` protocol.
+```
 
-Then inject the schema when instantiating a `ProjectConfig`:
+Then inject the schema when instantiating a `UserConfig`:
 
 ```python
-from maison import ProjectConfig
+from maison import UserConfig
 
-config = ProjectConfig(project_name="acme", config_schema=MySchema)
+config = UserConfig(project_name="acme", schema=MySchema)
 ```
 
 To validate the config, simply run `validate()` on the config instance:
@@ -158,14 +163,15 @@ To validate the config, simply run `validate()` on the config instance:
 config.validate()
 ```
 
-If the configuration is invalid, a `pydantic` `ValidationError` will be raised. If the
-configuration is valid, the validated values are returned.
+If the configuration is invalid and if you are using a `pydantic` base model as
+your schema, a `pydantic` `ValidationError` will be raised. If the configuration
+is valid, the validated values are returned.
 
 If `validate` is invoked but no schema has been provided, a `NoSchemaError` will
 be raised. A schema can be added after instantiation through a setter:
 
 ```python
-config.config_schema = MySchema
+config.schema = MySchema
 ```
 
 ## Casting and default values
@@ -181,7 +187,7 @@ foo = 1
 And a schema that looks like this:
 
 ```python
-class MySchema(ConfigSchema):
+class MySchema(BaseModel):
   foo: str
   bar: str = "my_default"
 ```
@@ -189,13 +195,13 @@ class MySchema(ConfigSchema):
 Running the config through validation will render the following:
 
 ```python
-config = ProjectConfig(project_name="acme", config_schema=MySchema)
+config = UserConfig(project_name="acme", schema=MySchema)
 
-print(config.to_dict())
+print(config)
 #> {"foo": 1}
 
 config.validate()
-print(config.to_dict())
+print(config)
 #> {"foo": "1", "bar": "my_default"}
 ```
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,6 @@ nox.options.sessions = (
     "mypy",
     "tests",
     "typeguard",
-    "xdoctest",
     "docs-build",
 )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -120,7 +120,7 @@ def mypy(session: Session) -> None:
     """Type-check using mypy."""
     args = session.posargs or ["src", "tests", "docs/conf.py"]
     session.install(".")
-    session.install("mypy", "pytest", "types-toml")
+    session.install("mypy", "pytest", "types-toml", "pydantic")
     session.run("mypy", *args)
     if not session.posargs:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
@@ -130,7 +130,7 @@ def mypy(session: Session) -> None:
 def tests(session: Session) -> None:
     """Run the test suite."""
     session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments")
+    session.install("coverage[toml]", "pytest", "pygments", "pydantic")
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
@@ -155,7 +155,7 @@ def coverage(session: Session) -> None:
 def typeguard(session: Session) -> None:
     """Runtime type checking using Typeguard."""
     session.install(".")
-    session.install("pytest", "typeguard", "pygments")
+    session.install("pytest", "typeguard", "pygments", "pydantic")
     session.run("pytest", f"--typeguard-packages={package}", *session.posargs)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,17 @@ files = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+description = "Reusable constraint types to use with typing.Annotated"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
+    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
+]
+
+[[package]]
 name = "anyio"
 version = "4.4.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -853,6 +864,129 @@ files = [
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
+name = "pydantic"
+version = "2.8.2"
+description = "Data validation using Python type hints"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
+    {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
+]
+
+[package.dependencies]
+annotated-types = ">=0.4.0"
+pydantic-core = "2.20.1"
+typing-extensions = [
+    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
+    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
+]
+
+[package.extras]
+email = ["email-validator (>=2.0.0)"]
+
+[[package]]
+name = "pydantic-core"
+version = "2.20.1"
+description = "Core functionality for Pydantic validation and serialization"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f239eb799a2081495ea659d8d4a43a8f42cd1fe9ff2e7e436295c38a10c286a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53e431da3fc53360db73eedf6f7124d1076e1b4ee4276b36fb25514544ceb4a3"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1f62b2413c3a0e846c3b838b2ecd6c7a19ec6793b2a522745b0869e37ab5bc1"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d41e6daee2813ecceea8eda38062d69e280b39df793f5a942fa515b8ed67953"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d482efec8b7dc6bfaedc0f166b2ce349df0011f5d2f1f25537ced4cfc34fd98"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e93e1a4b4b33daed65d781a57a522ff153dcf748dee70b40c7258c5861e1768a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7c4ea22b6739b162c9ecaaa41d718dfad48a244909fe7ef4b54c0b530effc5a"},
+    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4f2790949cf385d985a31984907fecb3896999329103df4e4983a4a41e13e840"},
+    {file = "pydantic_core-2.20.1-cp310-none-win32.whl", hash = "sha256:5e999ba8dd90e93d57410c5e67ebb67ffcaadcea0ad973240fdfd3a135506250"},
+    {file = "pydantic_core-2.20.1-cp310-none-win_amd64.whl", hash = "sha256:512ecfbefef6dac7bc5eaaf46177b2de58cdf7acac8793fe033b24ece0b9566c"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d2a8fa9d6d6f891f3deec72f5cc668e6f66b188ab14bb1ab52422fe8e644f312"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:175873691124f3d0da55aeea1d90660a6ea7a3cfea137c38afa0a5ffabe37b88"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37eee5b638f0e0dcd18d21f59b679686bbd18917b87db0193ae36f9c23c355fc"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25e9185e2d06c16ee438ed39bf62935ec436474a6ac4f9358524220f1b236e43"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:150906b40ff188a3260cbee25380e7494ee85048584998c1e66df0c7a11c17a6"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ad4aeb3e9a97286573c03df758fc7627aecdd02f1da04516a86dc159bf70121"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f3ed29cd9f978c604708511a1f9c2fdcb6c38b9aae36a51905b8811ee5cbf1"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0dae11d8f5ded51699c74d9548dcc5938e0804cc8298ec0aa0da95c21fff57b"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:faa6b09ee09433b87992fb5a2859efd1c264ddc37280d2dd5db502126d0e7f27"},
+    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9dc1b507c12eb0481d071f3c1808f0529ad41dc415d0ca11f7ebfc666e66a18b"},
+    {file = "pydantic_core-2.20.1-cp311-none-win32.whl", hash = "sha256:fa2fddcb7107e0d1808086ca306dcade7df60a13a6c347a7acf1ec139aa6789a"},
+    {file = "pydantic_core-2.20.1-cp311-none-win_amd64.whl", hash = "sha256:40a783fb7ee353c50bd3853e626f15677ea527ae556429453685ae32280c19c2"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:595ba5be69b35777474fa07f80fc260ea71255656191adb22a8c53aba4479231"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4f55095ad087474999ee28d3398bae183a66be4823f753cd7d67dd0153427c9"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9aa05d09ecf4c75157197f27cdc9cfaeb7c5f15021c6373932bf3e124af029f"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e97fdf088d4b31ff4ba35db26d9cc472ac7ef4a2ff2badeabf8d727b3377fc52"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc633a9fe1eb87e250b5c57d389cf28998e4292336926b0b6cdaee353f89a237"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d573faf8eb7e6b1cbbcb4f5b247c60ca8be39fe2c674495df0eb4318303137fe"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dc97754b57d2fd00ac2b24dfa341abffc380b823211994c4efac7f13b9e90e"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33499e85e739a4b60c9dac710c20a08dc73cb3240c9a0e22325e671b27b70d24"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bebb4d6715c814597f85297c332297c6ce81e29436125ca59d1159b07f423eb1"},
+    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:516d9227919612425c8ef1c9b869bbbee249bc91912c8aaffb66116c0b447ebd"},
+    {file = "pydantic_core-2.20.1-cp312-none-win32.whl", hash = "sha256:469f29f9093c9d834432034d33f5fe45699e664f12a13bf38c04967ce233d688"},
+    {file = "pydantic_core-2.20.1-cp312-none-win_amd64.whl", hash = "sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0827505a5c87e8aa285dc31e9ec7f4a17c81a813d45f70b1d9164e03a813a686"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19c0fa39fa154e7e0b7f82f88ef85faa2a4c23cc65aae2f5aea625e3c13c735a"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa223cd1e36b642092c326d694d8bf59b71ddddc94cdb752bbbb1c5c91d833b"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c336a6d235522a62fef872c6295a42ecb0c4e1d0f1a3e500fe949415761b8a19"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eb6a0587eded33aeefea9f916899d42b1799b7b14b8f8ff2753c0ac1741edac"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70c8daf4faca8da5a6d655f9af86faf6ec2e1768f4b8b9d0226c02f3d6209703"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9fa4c9bf273ca41f940bceb86922a7667cd5bf90e95dbb157cbb8441008482c"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11b71d67b4725e7e2a9f6e9c0ac1239bbc0c48cce3dc59f98635efc57d6dac83"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:270755f15174fb983890c49881e93f8f1b80f0b5e3a3cc1394a255706cabd203"},
+    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c81131869240e3e568916ef4c307f8b99583efaa60a8112ef27a366eefba8ef0"},
+    {file = "pydantic_core-2.20.1-cp313-none-win32.whl", hash = "sha256:b91ced227c41aa29c672814f50dbb05ec93536abf8f43cd14ec9521ea09afe4e"},
+    {file = "pydantic_core-2.20.1-cp313-none-win_amd64.whl", hash = "sha256:65db0f2eefcaad1a3950f498aabb4875c8890438bc80b19362cf633b87a8ab20"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:4745f4ac52cc6686390c40eaa01d48b18997cb130833154801a442323cc78f91"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8ad4c766d3f33ba8fd692f9aa297c9058970530a32c728a2c4bfd2616d3358b"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e81317dd6a0127cabce83c0c9c3fbecceae981c8391e6f1dec88a77c8a569a"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaad4ff2de1c3823fddf82f41121bdf453d922e9a238642b1dedb33c4e4f98ad"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ab812fa0c845df815e506be30337e2df27e88399b985d0bb4e3ecfe72df31c"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5ebac750d9d5f2706654c638c041635c385596caf68f81342011ddfa1e5598"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2aafc5a503855ea5885559eae883978c9b6d8c8993d67766ee73d82e841300dd"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4868f6bd7c9d98904b748a2653031fc9c2f85b6237009d475b1008bfaeb0a5aa"},
+    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa2f457b4af386254372dfa78a2eda2563680d982422641a85f271c859df1987"},
+    {file = "pydantic_core-2.20.1-cp38-none-win32.whl", hash = "sha256:225b67a1f6d602de0ce7f6c1c3ae89a4aa25d3de9be857999e9124f15dab486a"},
+    {file = "pydantic_core-2.20.1-cp38-none-win_amd64.whl", hash = "sha256:6b507132dcfc0dea440cce23ee2182c0ce7aba7054576efc65634f080dbe9434"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b03f7941783b4c4a26051846dea594628b38f6940a2fdc0df00b221aed39314c"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1eedfeb6089ed3fad42e81a67755846ad4dcc14d73698c120a82e4ccf0f1f9f6"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635fee4e041ab9c479e31edda27fcf966ea9614fff1317e280d99eb3e5ab6fe2"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:77bf3ac639c1ff567ae3b47f8d4cc3dc20f9966a2a6dd2311dcc055d3d04fb8a"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ed1b0132f24beeec5a78b67d9388656d03e6a7c837394f99257e2d55b461611"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6514f963b023aeee506678a1cf821fe31159b925c4b76fe2afa94cc70b3222b"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10d4204d8ca33146e761c79f83cc861df20e7ae9f6487ca290a97702daf56006"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d036c7187b9422ae5b262badb87a20a49eb6c5238b2004e96d4da1231badef1"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ebfef07dbe1d93efb94b4700f2d278494e9162565a54f124c404a5656d7ff09"},
+    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6b9d9bb600328a1ce523ab4f454859e9d439150abb0906c5a1983c146580ebab"},
+    {file = "pydantic_core-2.20.1-cp39-none-win32.whl", hash = "sha256:784c1214cb6dd1e3b15dd8b91b9a53852aed16671cc3fbe4786f4f1db07089e2"},
+    {file = "pydantic_core-2.20.1-cp39-none-win_amd64.whl", hash = "sha256:d2fe69c5434391727efa54b47a1e7986bb0186e72a41b203df8f5b0a19a4f669"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a45f84b09ac9c3d35dfcf6a27fd0634d30d183205230a0ebe8373a0e8cfa0906"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d02a72df14dfdbaf228424573a07af10637bd490f0901cee872c4f434a735b94"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2b27e6af28f07e2f195552b37d7d66b150adbaa39a6d327766ffd695799780f"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084659fac3c83fd674596612aeff6041a18402f1e1bc19ca39e417d554468482"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:242b8feb3c493ab78be289c034a1f659e8826e2233786e36f2893a950a719bb6"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:38cf1c40a921d05c5edc61a785c0ddb4bed67827069f535d794ce6bcded919fc"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0bbdd76ce9aa5d4209d65f2b27fc6e5ef1312ae6c5333c26db3f5ade53a1e99"},
+    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:254ec27fdb5b1ee60684f91683be95e5133c994cc54e86a0b0963afa25c8f8a6"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:407653af5617f0757261ae249d3fba09504d7a71ab36ac057c938572d1bc9331"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c693e916709c2465b02ca0ad7b387c4f8423d1db7b4649c551f27a529181c5ad"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5ff4911aea936a47d9376fd3ab17e970cc543d1b68921886e7f64bd28308d1"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f55a886d74f1808763976ac4efd29b7ed15c69f4d838bbd74d9d09cf6fa86"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:964faa8a861d2664f0c7ab0c181af0bea66098b1919439815ca8803ef136fc4e"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4dd484681c15e6b9a977c785a345d3e378d72678fd5f1f3c0509608da24f2ac0"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f6d6cff3538391e8486a431569b77921adfcdef14eb18fbf19b7c0a5294d4e6a"},
+    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a6d511cc297ff0883bc3708b465ff82d7560193169a8b93260f74ecb0a5e08a7"},
+    {file = "pydantic_core-2.20.1.tar.gz", hash = "sha256:26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
+
+[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1115,6 +1249,17 @@ files = [
 core = ["importlib-metadata (>=6)", "importlib-resources (>=5.10.2)", "jaraco.text (>=3.7)", "more-itertools (>=8.8)", "ordered-set (>=3.1.1)", "packaging (>=24)", "platformdirs (>=2.6.2)", "tomli (>=2.0.1)", "wheel (>=0.43.0)"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.11.*)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (<0.4)", "pytest-ruff (>=0.2.1)", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "sniffio"
@@ -1657,4 +1802,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.1"
-content-hash = "a021e1983967be0112996202172fc1f757ef0ee07975dc7533c8f6f633faf20e"
+content-hash = "9cadfd716b0a0c136f63e8747c10c84cfff08c66a4e33321ad7bc5aef4095ffe"

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,17 +12,6 @@ files = [
 ]
 
 [[package]]
-name = "annotated-types"
-version = "0.7.0"
-description = "Reusable constraint types to use with typing.Annotated"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
-    {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
-]
-
-[[package]]
 name = "anyio"
 version = "4.4.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -864,129 +853,6 @@ files = [
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
-name = "pydantic"
-version = "2.8.2"
-description = "Data validation using Python type hints"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pydantic-2.8.2-py3-none-any.whl", hash = "sha256:73ee9fddd406dc318b885c7a2eab8a6472b68b8fb5ba8150949fc3db939f23c8"},
-    {file = "pydantic-2.8.2.tar.gz", hash = "sha256:6f62c13d067b0755ad1c21a34bdd06c0c12625a22b0fc09c6b149816604f7c2a"},
-]
-
-[package.dependencies]
-annotated-types = ">=0.4.0"
-pydantic-core = "2.20.1"
-typing-extensions = [
-    {version = ">=4.12.2", markers = "python_version >= \"3.13\""},
-    {version = ">=4.6.1", markers = "python_version < \"3.13\""},
-]
-
-[package.extras]
-email = ["email-validator (>=2.0.0)"]
-
-[[package]]
-name = "pydantic-core"
-version = "2.20.1"
-description = "Core functionality for Pydantic validation and serialization"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3acae97ffd19bf091c72df4d726d552c473f3576409b2a7ca36b2f535ffff4a3"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:41f4c96227a67a013e7de5ff8f20fb496ce573893b7f4f2707d065907bffdbd6"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f239eb799a2081495ea659d8d4a43a8f42cd1fe9ff2e7e436295c38a10c286a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53e431da3fc53360db73eedf6f7124d1076e1b4ee4276b36fb25514544ceb4a3"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1f62b2413c3a0e846c3b838b2ecd6c7a19ec6793b2a522745b0869e37ab5bc1"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d41e6daee2813ecceea8eda38062d69e280b39df793f5a942fa515b8ed67953"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d482efec8b7dc6bfaedc0f166b2ce349df0011f5d2f1f25537ced4cfc34fd98"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e93e1a4b4b33daed65d781a57a522ff153dcf748dee70b40c7258c5861e1768a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e7c4ea22b6739b162c9ecaaa41d718dfad48a244909fe7ef4b54c0b530effc5a"},
-    {file = "pydantic_core-2.20.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4f2790949cf385d985a31984907fecb3896999329103df4e4983a4a41e13e840"},
-    {file = "pydantic_core-2.20.1-cp310-none-win32.whl", hash = "sha256:5e999ba8dd90e93d57410c5e67ebb67ffcaadcea0ad973240fdfd3a135506250"},
-    {file = "pydantic_core-2.20.1-cp310-none-win_amd64.whl", hash = "sha256:512ecfbefef6dac7bc5eaaf46177b2de58cdf7acac8793fe033b24ece0b9566c"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d2a8fa9d6d6f891f3deec72f5cc668e6f66b188ab14bb1ab52422fe8e644f312"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:175873691124f3d0da55aeea1d90660a6ea7a3cfea137c38afa0a5ffabe37b88"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:37eee5b638f0e0dcd18d21f59b679686bbd18917b87db0193ae36f9c23c355fc"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25e9185e2d06c16ee438ed39bf62935ec436474a6ac4f9358524220f1b236e43"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:150906b40ff188a3260cbee25380e7494ee85048584998c1e66df0c7a11c17a6"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ad4aeb3e9a97286573c03df758fc7627aecdd02f1da04516a86dc159bf70121"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d3f3ed29cd9f978c604708511a1f9c2fdcb6c38b9aae36a51905b8811ee5cbf1"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b0dae11d8f5ded51699c74d9548dcc5938e0804cc8298ec0aa0da95c21fff57b"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:faa6b09ee09433b87992fb5a2859efd1c264ddc37280d2dd5db502126d0e7f27"},
-    {file = "pydantic_core-2.20.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9dc1b507c12eb0481d071f3c1808f0529ad41dc415d0ca11f7ebfc666e66a18b"},
-    {file = "pydantic_core-2.20.1-cp311-none-win32.whl", hash = "sha256:fa2fddcb7107e0d1808086ca306dcade7df60a13a6c347a7acf1ec139aa6789a"},
-    {file = "pydantic_core-2.20.1-cp311-none-win_amd64.whl", hash = "sha256:40a783fb7ee353c50bd3853e626f15677ea527ae556429453685ae32280c19c2"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:595ba5be69b35777474fa07f80fc260ea71255656191adb22a8c53aba4479231"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a4f55095ad087474999ee28d3398bae183a66be4823f753cd7d67dd0153427c9"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9aa05d09ecf4c75157197f27cdc9cfaeb7c5f15021c6373932bf3e124af029f"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e97fdf088d4b31ff4ba35db26d9cc472ac7ef4a2ff2badeabf8d727b3377fc52"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bc633a9fe1eb87e250b5c57d389cf28998e4292336926b0b6cdaee353f89a237"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d573faf8eb7e6b1cbbcb4f5b247c60ca8be39fe2c674495df0eb4318303137fe"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26dc97754b57d2fd00ac2b24dfa341abffc380b823211994c4efac7f13b9e90e"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:33499e85e739a4b60c9dac710c20a08dc73cb3240c9a0e22325e671b27b70d24"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bebb4d6715c814597f85297c332297c6ce81e29436125ca59d1159b07f423eb1"},
-    {file = "pydantic_core-2.20.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:516d9227919612425c8ef1c9b869bbbee249bc91912c8aaffb66116c0b447ebd"},
-    {file = "pydantic_core-2.20.1-cp312-none-win32.whl", hash = "sha256:469f29f9093c9d834432034d33f5fe45699e664f12a13bf38c04967ce233d688"},
-    {file = "pydantic_core-2.20.1-cp312-none-win_amd64.whl", hash = "sha256:035ede2e16da7281041f0e626459bcae33ed998cca6a0a007a5ebb73414ac72d"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0827505a5c87e8aa285dc31e9ec7f4a17c81a813d45f70b1d9164e03a813a686"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19c0fa39fa154e7e0b7f82f88ef85faa2a4c23cc65aae2f5aea625e3c13c735a"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa223cd1e36b642092c326d694d8bf59b71ddddc94cdb752bbbb1c5c91d833b"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c336a6d235522a62fef872c6295a42ecb0c4e1d0f1a3e500fe949415761b8a19"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7eb6a0587eded33aeefea9f916899d42b1799b7b14b8f8ff2753c0ac1741edac"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:70c8daf4faca8da5a6d655f9af86faf6ec2e1768f4b8b9d0226c02f3d6209703"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9fa4c9bf273ca41f940bceb86922a7667cd5bf90e95dbb157cbb8441008482c"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:11b71d67b4725e7e2a9f6e9c0ac1239bbc0c48cce3dc59f98635efc57d6dac83"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:270755f15174fb983890c49881e93f8f1b80f0b5e3a3cc1394a255706cabd203"},
-    {file = "pydantic_core-2.20.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:c81131869240e3e568916ef4c307f8b99583efaa60a8112ef27a366eefba8ef0"},
-    {file = "pydantic_core-2.20.1-cp313-none-win32.whl", hash = "sha256:b91ced227c41aa29c672814f50dbb05ec93536abf8f43cd14ec9521ea09afe4e"},
-    {file = "pydantic_core-2.20.1-cp313-none-win_amd64.whl", hash = "sha256:65db0f2eefcaad1a3950f498aabb4875c8890438bc80b19362cf633b87a8ab20"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:4745f4ac52cc6686390c40eaa01d48b18997cb130833154801a442323cc78f91"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a8ad4c766d3f33ba8fd692f9aa297c9058970530a32c728a2c4bfd2616d3358b"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41e81317dd6a0127cabce83c0c9c3fbecceae981c8391e6f1dec88a77c8a569a"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04024d270cf63f586ad41fff13fde4311c4fc13ea74676962c876d9577bcc78f"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eaad4ff2de1c3823fddf82f41121bdf453d922e9a238642b1dedb33c4e4f98ad"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26ab812fa0c845df815e506be30337e2df27e88399b985d0bb4e3ecfe72df31c"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3c5ebac750d9d5f2706654c638c041635c385596caf68f81342011ddfa1e5598"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2aafc5a503855ea5885559eae883978c9b6d8c8993d67766ee73d82e841300dd"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4868f6bd7c9d98904b748a2653031fc9c2f85b6237009d475b1008bfaeb0a5aa"},
-    {file = "pydantic_core-2.20.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa2f457b4af386254372dfa78a2eda2563680d982422641a85f271c859df1987"},
-    {file = "pydantic_core-2.20.1-cp38-none-win32.whl", hash = "sha256:225b67a1f6d602de0ce7f6c1c3ae89a4aa25d3de9be857999e9124f15dab486a"},
-    {file = "pydantic_core-2.20.1-cp38-none-win_amd64.whl", hash = "sha256:6b507132dcfc0dea440cce23ee2182c0ce7aba7054576efc65634f080dbe9434"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b03f7941783b4c4a26051846dea594628b38f6940a2fdc0df00b221aed39314c"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1eedfeb6089ed3fad42e81a67755846ad4dcc14d73698c120a82e4ccf0f1f9f6"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635fee4e041ab9c479e31edda27fcf966ea9614fff1317e280d99eb3e5ab6fe2"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:77bf3ac639c1ff567ae3b47f8d4cc3dc20f9966a2a6dd2311dcc055d3d04fb8a"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ed1b0132f24beeec5a78b67d9388656d03e6a7c837394f99257e2d55b461611"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c6514f963b023aeee506678a1cf821fe31159b925c4b76fe2afa94cc70b3222b"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10d4204d8ca33146e761c79f83cc861df20e7ae9f6487ca290a97702daf56006"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2d036c7187b9422ae5b262badb87a20a49eb6c5238b2004e96d4da1231badef1"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9ebfef07dbe1d93efb94b4700f2d278494e9162565a54f124c404a5656d7ff09"},
-    {file = "pydantic_core-2.20.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6b9d9bb600328a1ce523ab4f454859e9d439150abb0906c5a1983c146580ebab"},
-    {file = "pydantic_core-2.20.1-cp39-none-win32.whl", hash = "sha256:784c1214cb6dd1e3b15dd8b91b9a53852aed16671cc3fbe4786f4f1db07089e2"},
-    {file = "pydantic_core-2.20.1-cp39-none-win_amd64.whl", hash = "sha256:d2fe69c5434391727efa54b47a1e7986bb0186e72a41b203df8f5b0a19a4f669"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a45f84b09ac9c3d35dfcf6a27fd0634d30d183205230a0ebe8373a0e8cfa0906"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:d02a72df14dfdbaf228424573a07af10637bd490f0901cee872c4f434a735b94"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d2b27e6af28f07e2f195552b37d7d66b150adbaa39a6d327766ffd695799780f"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:084659fac3c83fd674596612aeff6041a18402f1e1bc19ca39e417d554468482"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:242b8feb3c493ab78be289c034a1f659e8826e2233786e36f2893a950a719bb6"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:38cf1c40a921d05c5edc61a785c0ddb4bed67827069f535d794ce6bcded919fc"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e0bbdd76ce9aa5d4209d65f2b27fc6e5ef1312ae6c5333c26db3f5ade53a1e99"},
-    {file = "pydantic_core-2.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:254ec27fdb5b1ee60684f91683be95e5133c994cc54e86a0b0963afa25c8f8a6"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:407653af5617f0757261ae249d3fba09504d7a71ab36ac057c938572d1bc9331"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:c693e916709c2465b02ca0ad7b387c4f8423d1db7b4649c551f27a529181c5ad"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b5ff4911aea936a47d9376fd3ab17e970cc543d1b68921886e7f64bd28308d1"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:177f55a886d74f1808763976ac4efd29b7ed15c69f4d838bbd74d9d09cf6fa86"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:964faa8a861d2664f0c7ab0c181af0bea66098b1919439815ca8803ef136fc4e"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:4dd484681c15e6b9a977c785a345d3e378d72678fd5f1f3c0509608da24f2ac0"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f6d6cff3538391e8486a431569b77921adfcdef14eb18fbf19b7c0a5294d4e6a"},
-    {file = "pydantic_core-2.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a6d511cc297ff0883bc3708b465ff82d7560193169a8b93260f74ecb0a5e08a7"},
-    {file = "pydantic_core-2.20.1.tar.gz", hash = "sha256:26ca695eeee5f9f1aeeb211ffc12f10bcb6f71e2989988fda61dabd65db878d4"},
-]
-
-[package.dependencies]
-typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
-
-[[package]]
 name = "pygments"
 version = "2.18.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -1791,4 +1657,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9.1"
-content-hash = "8b28a69eb882dab4d429d5839ad4ed98a8e021f50c35734684d1ca825b8954f5"
+content-hash = "a021e1983967be0112996202172fc1f757ef0ee07975dc7533c8f6f633faf20e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ toml = "^0.10.2"
 pytest = "^8.3.0"
 pydantic = "^2.8.2"
 coverage = {extras = ["toml"], version = "^7.4.0"}
+six = "^1.16.0"
 
 [tool.poetry.group.dev.dependencies]
 typeguard = "^4.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ Changelog = "https://github.com/dbatten5/maison/releases"
 [tool.poetry.dependencies]
 python = "^3.9.1"
 click = "^8.0.1"
-pydantic = "^2.5.3"
 toml = "^0.10.2"
 
 [tool.poetry.group.test.dependencies]
@@ -75,11 +74,13 @@ ignore_missing_imports = true
 
 [tool.ruff]
 src = ['src', 'tests']
+line-length = 88
+target-version = 'py37'
+
+[tool.ruff.lint]
 ignore = [
   'B019',
 ]
-line-length = 88
-target-version = 'py37'
 select = [
     'A',
     'ARG',
@@ -109,23 +110,24 @@ select = [
     'W',
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ['F401']
 "tests/*" = [
     'S',
+    'D102',
     'D212',
     'D415',
     'D205',
     'D104',
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = 'google'
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-single-line = true
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ toml = "^0.10.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.0"
+pydantic = "^2.8.2"
 coverage = {extras = ["toml"], version = "^7.4.0"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/maison/__init__.py
+++ b/src/maison/__init__.py
@@ -1,6 +1,5 @@
 """Maison."""
 
-from .config import ProjectConfig
-from .schema import ConfigSchema
+from .config import UserConfig
 
-__all__ = ["ProjectConfig", "ConfigSchema"]
+__all__ = ["UserConfig"]

--- a/src/maison/config.py
+++ b/src/maison/config.py
@@ -27,7 +27,7 @@ class UserConfig:
 
     def __init__(
         self,
-        project_name: str,
+        package_name: str,
         starting_path: Optional[Path] = None,
         source_files: Optional[List[str]] = None,
         schema: Optional[Type[_IsSchema]] = None,
@@ -36,7 +36,7 @@ class UserConfig:
         """Initialize the config.
 
         Args:
-            project_name: the name of the project, to be used to find the right section
+            package_name: the name of the package, to be used to find the right section
                 in the config file
             starting_path: an optional starting path to start the search for config
                 file
@@ -49,7 +49,7 @@ class UserConfig:
         self.source_files = source_files or ["pyproject.toml"]
         self.merge_configs = merge_configs
         self._sources = _collect_configs(
-            project_name=project_name,
+            package_name=package_name,
             source_files=self.source_files,
             starting_path=starting_path,
         )
@@ -168,13 +168,13 @@ class UserConfig:
         return self.values
 
     def _generate_config_dict(self) -> Dict[str, Any]:
-        """Generate the project config dict.
+        """Generate the config dict.
 
         If `merge_configs` is set to `False` then we use the first config. If `True`
         then the dicts of the sources are merged from right to left.
 
         Returns:
-            the project config dict
+            the config dict
         """
         if len(self._sources) == 0:
             return {}

--- a/src/maison/config.py
+++ b/src/maison/config.py
@@ -155,7 +155,7 @@ class UserConfig:
         Raises:
             NoSchemaError: when validation is attempted but no schema has been provided
         """
-        selected_schema: Type[_IsSchema] | None = schema or self.schema  # type: ignore
+        selected_schema: Union[Type[_IsSchema], None] = schema or self.schema
 
         if not selected_schema:
             raise NoSchemaError

--- a/src/maison/config.py
+++ b/src/maison/config.py
@@ -1,4 +1,4 @@
-"""Module to hold the `ProjectConfig` class definition."""
+"""Module to hold the `UserConfig` class definition."""
 
 from functools import reduce
 from pathlib import Path
@@ -6,24 +6,31 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Protocol
 from typing import Type
 from typing import Union
 
 from maison.errors import NoSchemaError
-from maison.schema import ConfigSchema
 from maison.utils import _collect_configs
 from maison.utils import deep_merge
 
 
-class ProjectConfig:
-    """Defines the `ProjectConfig` and provides accessors to get config values."""
+class _IsSchema(Protocol):
+    """Protocol for config schemas."""
+
+    def dict(self) -> Dict[Any, Any]:
+        """Convert the validated config to a dict."""
+
+
+class UserConfig:
+    """Model the user configuration."""
 
     def __init__(
         self,
         project_name: str,
         starting_path: Optional[Path] = None,
         source_files: Optional[List[str]] = None,
-        config_schema: Optional[Type[ConfigSchema]] = None,
+        schema: Optional[Type[_IsSchema]] = None,
         merge_configs: bool = False,
     ) -> None:
         """Initialize the config.
@@ -35,7 +42,7 @@ class ProjectConfig:
                 file
             source_files: an optional list of source config filenames or absolute paths
                 to search for. If none is provided then `pyproject.toml` will be used.
-            config_schema: an optional `pydantic` model to define the config schema
+            schema: an optional `pydantic` model to define the config schema
             merge_configs: an optional boolean to determine whether configs should be
                 merged if multiple are found
         """
@@ -46,28 +53,43 @@ class ProjectConfig:
             source_files=self.source_files,
             starting_path=starting_path,
         )
-        self._config_dict = self._generate_config_dict()
-        self._config_schema = config_schema
-
-    def __repr__(self) -> str:
-        """Return the __repr__.
-
-        Returns:
-            the representation
-        """
-        return f"<class '{self.__class__.__name__}'>"
+        self._schema = schema
+        self._values = self._generate_config_dict()
 
     def __str__(self) -> str:
         """Return the __str__.
 
         Returns:
-            the representation
+            the string representation
         """
-        return self.__repr__()
+        return f"<class '{self.__class__.__name__}'>"
 
     @property
-    def config_path(self) -> Optional[Union[Path, List[Path]]]:
-        """Return a list of the path(s) to the config source(s).
+    def values(self) -> Dict[str, Any]:
+        """Return the user's configuration values.
+
+        Returns:
+            the user's configuration values
+        """
+        return self._values
+
+    @values.setter
+    def values(self, values: Dict[str, Any]) -> None:
+        """Set the user's configuration values."""
+        self._values = values
+
+    @property
+    def discovered_paths(self) -> List[Path]:
+        """Return a list of the paths to the config sources found on the filesystem.
+
+        Returns:
+            a list of the paths to the config sources
+        """
+        return [source.filepath for source in self._sources]
+
+    @property
+    def path(self) -> Optional[Union[Path, List[Path]]]:
+        """Return the path to the selected config source.
 
         Returns:
             `None` is no config sources have been found, a list of the found config
@@ -78,44 +100,27 @@ class ProjectConfig:
             return None
 
         if self.merge_configs:
-            return self.discovered_config_paths
+            return self.discovered_paths
 
-        return self.discovered_config_paths[0]
-
-    @property
-    def discovered_config_paths(self) -> List[Path]:
-        """Return a list of the paths to the config sources found on the filesystem.
-
-        Returns:
-            a list of the paths to the config sources
-        """
-        return [source.filepath for source in self._sources]
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Return a dict of all the config options.
-
-        Returns:
-            a dict of the config options
-        """
-        return self._config_dict
+        return self.discovered_paths[0]
 
     @property
-    def config_schema(self) -> Optional[Type[ConfigSchema]]:
-        """Return the `config_schema`.
+    def schema(self) -> Optional[Type[_IsSchema]]:
+        """Return the schema.
 
         Returns:
-            the `config_schema`
+            the schema
         """
-        return self._config_schema
+        return self._schema
 
-    @config_schema.setter
-    def config_schema(self, config_schema: Type[ConfigSchema]) -> None:
-        """Set the `config_schema`."""
-        self._config_schema = config_schema
+    @schema.setter
+    def schema(self, schema: Type[_IsSchema]) -> None:
+        """Set the schema."""
+        self._schema = schema
 
     def validate(
         self,
-        config_schema: Optional[Type[ConfigSchema]] = None,
+        schema: Optional[Type[_IsSchema]] = None,
         use_schema_values: bool = True,
     ) -> Dict[str, Any]:
         """Validate the configuration.
@@ -136,8 +141,9 @@ class ProjectConfig:
                 {"foo": "1"}
 
         Args:
-            config_schema: an optional `ConfigSchema` to define the schema. This
-                takes precedence over a schema provided at object instantiation.
+            schema: an optional class that follows the `IsSchema` protocol that
+                defines the schema. This takes precedence over a schema provided at
+                object instantiation.
             use_schema_values: an optional boolean to indicate whether the result
                 of passing the config through the schema should overwrite the existing
                 config values, meaning values are cast to types defined in the schema as
@@ -149,33 +155,19 @@ class ProjectConfig:
         Raises:
             NoSchemaError: when validation is attempted but no schema has been provided
         """
-        if not (config_schema or self.config_schema):
+        selected_schema: Type[_IsSchema] | None = schema or self.schema  # type: ignore
+
+        if not selected_schema:
             raise NoSchemaError
 
-        schema: Type[ConfigSchema] = config_schema or self.config_schema  # type: ignore
-
-        validated_schema = schema(**self._config_dict)
+        validated_schema = selected_schema(**self.values)
 
         if use_schema_values:
-            self._config_dict = validated_schema.dict()
+            self.values = validated_schema.dict()
 
-        return self._config_dict
+        return self.values
 
-    def get_option(
-        self, option_name: str, default_value: Optional[Any] = None
-    ) -> Optional[Any]:
-        """Return the value of a config option.
-
-        Args:
-            option_name: the config option for which to return the value
-            default_value: an option default value if the option isn't set
-
-        Returns:
-            The value of the given config option or `None` if it doesn't exist
-        """
-        return self._config_dict.get(option_name, default_value)
-
-    def _generate_config_dict(self) -> Dict[Any, Any]:
+    def _generate_config_dict(self) -> Dict[str, Any]:
         """Generate the project config dict.
 
         If `merge_configs` is set to `False` then we use the first config. If `True`
@@ -190,5 +182,5 @@ class ProjectConfig:
         if not self.merge_configs:
             return self._sources[0].to_dict()
 
-        source_dicts = [source.to_dict() for source in self._sources]
+        source_dicts = (source.to_dict() for source in self._sources)
         return reduce(lambda a, b: deep_merge(a, b), source_dicts)

--- a/src/maison/config.py
+++ b/src/maison/config.py
@@ -18,7 +18,7 @@ from maison.utils import deep_merge
 class _IsSchema(Protocol):
     """Protocol for config schemas."""
 
-    def dict(self) -> Dict[Any, Any]:
+    def model_dump(self) -> Dict[Any, Any]:
         """Convert the validated config to a dict."""
 
 
@@ -163,7 +163,7 @@ class UserConfig:
         validated_schema = selected_schema(**self.values)
 
         if use_schema_values:
-            self.values = validated_schema.dict()
+            self.values = validated_schema.model_dump()
 
         return self.values
 

--- a/src/maison/config_sources/base_source.py
+++ b/src/maison/config_sources/base_source.py
@@ -10,16 +10,16 @@ from typing import Dict
 class BaseSource(ABC):
     """Base class from which concrete source abstractions extend."""
 
-    def __init__(self, filepath: Path, project_name: str) -> None:
+    def __init__(self, filepath: Path, package_name: str) -> None:
         """Initialize the object.
 
         Args:
             filepath: the `Path` to the config file
-            project_name: the name of the project, used to pick out the relevant section
+            package_name: the name of the package, used to pick out the relevant section
                 in a `.toml` or `.ini` file
         """
         self.filepath = filepath
-        self.project_name = project_name
+        self.package_name = package_name
 
     def __repr__(self) -> str:
         """Return the __repr__.

--- a/src/maison/config_sources/pyproject_source.py
+++ b/src/maison/config_sources/pyproject_source.py
@@ -10,12 +10,12 @@ class PyprojectSource(TomlSource):
     """Class to represent a `pyproject.toml` config source."""
 
     def to_dict(self) -> Dict[Any, Any]:
-        """Convert the project `pyproject.toml` section to a dict.
+        """Convert the package `pyproject.toml` section to a dict.
 
-        Relies on the convention that config related to project `acme` will be located
-        under a `[tool.acme]` section in `pyproject.toml`
+        Relies on the convention that config related to package `acme` will be
+        located under a `[tool.acme]` section in `pyproject.toml`
 
         Returns:
             a dict of the config options and values
         """
-        return dict(self._load_file().get("tool", {}).get(self.project_name, {}))
+        return dict(self._load_file().get("tool", {}).get(self.package_name, {}))

--- a/src/maison/schema.py
+++ b/src/maison/schema.py
@@ -1,7 +1,0 @@
-"""Module to define the `ConfigSchema` class."""
-
-from pydantic import BaseModel
-
-
-class ConfigSchema(BaseModel):
-    """A class for creating schemas based on the `pydantic` `BaseModel`."""

--- a/src/maison/utils.py
+++ b/src/maison/utils.py
@@ -64,14 +64,14 @@ def _generate_search_paths(starting_path: Path) -> Generator[Path, None, None]:
 
 
 def _collect_configs(
-    project_name: str,
+    package_name: str,
     source_files: List[str],
     starting_path: Optional[Path] = None,
 ) -> List[BaseSource]:
     """Collect configs and return them in a list.
 
     Args:
-        project_name: the name of the project to be used to find the right section in
+        package_name: the name of the package to be used to find the right section in
             the config file
         source_files: a list of source config filenames to look for.
         starting_path: an optional starting path to start the search
@@ -94,7 +94,7 @@ def _collect_configs(
         # https://github.com/python/mypy/issues/5382#issuecomment-583901369
         source_kwargs: Dict[str, Any] = {
             "filepath": file_path,
-            "project_name": project_name,
+            "package_name": package_name,
         }
 
         if source.endswith("toml"):

--- a/src/maison/utils.py
+++ b/src/maison/utils.py
@@ -118,7 +118,6 @@ def deep_merge(destination: Dict[Any, Any], source: Dict[Any, Any]) -> Dict[Any,
     >>> deep_merge(a, b) == {
     ...     "first": {"all_rows": {"pass": "dog", "fail": "cat", "number": "5"}}
     ... }
-    True
 
     Note that the arguments may be modified!
 

--- a/tests/unit/config_sources/test_base_source.py
+++ b/tests/unit/config_sources/test_base_source.py
@@ -20,12 +20,7 @@ class TestRepr:
     """Tests for the `__repr__` method."""
 
     def test_contains_path(self) -> None:
-        """
-        Given a instance of an extension of `BaseSource`,
-        When the repr is invoked,
-        Then a useful repr is returned
-        """
-        source = ConcreteSource(filepath=Path("~/file.txt"), project_name="acme")
+        source = ConcreteSource(filepath=Path("~/file.txt"), package_name="acme")
 
         assert "file.txt" in repr(source)
         assert str(source) == repr(source)
@@ -35,13 +30,8 @@ class TestFilename:
     """Tests for the `filename` property."""
 
     def test_success(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a file,
-        When an extension of `BaseSource` is created with the file,
-        Then the filename can be retrieved
-        """
         path_to_file = create_tmp_file(filename="file.txt")
 
-        source = ConcreteSource(filepath=path_to_file, project_name="acme")
+        source = ConcreteSource(filepath=path_to_file, package_name="acme")
 
         assert source.filename == "file.txt"

--- a/tests/unit/config_sources/test_ini_source.py
+++ b/tests/unit/config_sources/test_ini_source.py
@@ -10,11 +10,7 @@ class TestToDict:
     """Tests for the `to_dict` method."""
 
     def test_success(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given an instance of `IniSource` instantiated with a `.ini` file,
-        When the `to_dict` method is called,
-        Then the `.ini` is loaded and converted to a `dict`
-        """
+        """A `.ini` file is converted to a `dict`"""
         ini_file = """
 [section 1]
 option_1 = value_1
@@ -24,7 +20,7 @@ option_2 = value_2
         """
         ini_path = create_tmp_file(content=ini_file, filename="foo.ini")
 
-        toml_source = IniSource(filepath=ini_path, project_name="acme")
+        toml_source = IniSource(filepath=ini_path, package_name="acme")
 
         assert toml_source.to_dict() == {
             "section 1": {"option_1": "value_1"},
@@ -32,13 +28,9 @@ option_2 = value_2
         }
 
     def test_empty_file(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given an instance of `IniSource` instantiated with an empty `.ini` file,
-        When the `to_dict` method is called,
-        Then an empty `dict` is returned
-        """
+        """Empty `.ini` returns an empty dict"""
         ini_path = create_tmp_file(filename="foo.ini")
 
-        toml_source = IniSource(filepath=ini_path, project_name="acme")
+        toml_source = IniSource(filepath=ini_path, package_name="acme")
 
         assert toml_source.to_dict() == {}

--- a/tests/unit/config_sources/test_pyproject_source.py
+++ b/tests/unit/config_sources/test_pyproject_source.py
@@ -10,43 +10,26 @@ class TestToDict:
     """Tests for the `to_dict` method."""
 
     def test_success(self, create_pyproject_toml: Callable[..., Path]) -> None:
-        """
-        Given an instance of `PyprojectSource` instantiated with
-            a valid `pyproject.toml` file,
-        When the `to_dict` method is called,
-        Then the `pyproject.toml` is loaded
-            and the relevant section is converted to a `dict`
-        """
         pyproject_path = create_pyproject_toml()
 
-        pyproject_source = PyprojectSource(filepath=pyproject_path, project_name="foo")
+        pyproject_source = PyprojectSource(filepath=pyproject_path, package_name="foo")
 
         assert pyproject_source.to_dict() == {"bar": "baz"}
 
     def test_unrecognised_section_name(
         self, create_pyproject_toml: Callable[..., Path]
     ) -> None:
-        """
-        Given an instance of `PyprojectSource` instantiated with
-            a valid `pyproject.toml` file but an unrecognised section name
-        When the `to_dict` method is called,
-        Then an empty dict is returned
-        """
+        """An empty dict is returned if the package name is not found"""
         pyproject_path = create_pyproject_toml(section_name="foo")
 
-        pyproject_source = PyprojectSource(filepath=pyproject_path, project_name="bar")
+        pyproject_source = PyprojectSource(filepath=pyproject_path, package_name="bar")
 
         assert pyproject_source.to_dict() == {}
 
     def test_unrecognised_format(self, create_toml: Callable[..., Path]) -> None:
-        """
-        Given an instance of `PyprojectSource` instantiated with
-            an invalid `pyproject.toml`
-        When the `to_dict` method is called,
-        Then an empty dict is returned
-        """
+        """An unrecognised format or pyproject.toml returns an empty dict"""
         pyproject_path = create_toml(filename="pyproject.toml", content={"foo": "bar"})
 
-        pyproject_source = PyprojectSource(filepath=pyproject_path, project_name="baz")
+        pyproject_source = PyprojectSource(filepath=pyproject_path, package_name="baz")
 
         assert pyproject_source.to_dict() == {}

--- a/tests/unit/config_sources/test_toml_source.py
+++ b/tests/unit/config_sources/test_toml_source.py
@@ -15,22 +15,15 @@ class TestToDict:
     """Tests for the `to_dict` method."""
 
     def test_success(self, create_toml: Callable[..., Path]) -> None:
-        """
-        Given an instance of `TomlSource` instantiated with a `.toml` file,
-        When the `to_dict` method is called,
-        Then the `.toml` is loaded and converted to a `dict`
-        """
+        """A `.toml` is loaded and converted to a `dict`"""
         toml_path = create_toml(filename="config.toml", content={"foo": "bar"})
 
-        toml_source = TomlSource(filepath=toml_path, project_name="acme")
+        toml_source = TomlSource(filepath=toml_path, package_name="acme")
 
         assert toml_source.to_dict() == {"foo": "bar"}
 
     def test_toml_decode_error(self, create_toml: Callable[..., Path]) -> None:
-        """
-        Given a `.toml` file containing duplicate keys, report on the filepath
-        of the `.toml` file that triggered the error.
-        """
+        """Toml decoding errors are reported"""
         toml_path = create_toml(filename="config.toml")
         toml_path.write_text(
             dedent(
@@ -42,7 +35,7 @@ class TestToDict:
             encoding="utf-8",
         )
 
-        toml_source = TomlSource(filepath=toml_path, project_name="acme")
+        toml_source = TomlSource(filepath=toml_path, package_name="acme")
 
         error_regex = re.escape(f"Error trying to load toml file '{toml_path!s}'")
         with pytest.raises(BadTomlError, match=error_regex):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,7 +17,7 @@ class TestUserConfig:
     def test_str(self, create_tmp_file: Callable[..., Path]) -> None:
         pyproject_path = create_tmp_file(filename="pyproject.toml")
 
-        config = UserConfig(project_name="foo", starting_path=pyproject_path)
+        config = UserConfig(package_name="foo", starting_path=pyproject_path)
 
         assert str(config) == "<class 'UserConfig'>"
 
@@ -29,7 +29,7 @@ class TestDictObject:
         """A valid pyproject is parsed to a dict object."""
         pyproject_path = create_pyproject_toml()
 
-        config = UserConfig(project_name="foo", starting_path=pyproject_path)
+        config = UserConfig(package_name="foo", starting_path=pyproject_path)
 
         assert config.values == {"bar": "baz"}
 
@@ -39,7 +39,7 @@ class TestSourceFiles:
 
     def test_not_found(self) -> None:
         """Non existent source files are handled."""
-        config = UserConfig(project_name="foo", source_files=["foo"])
+        config = UserConfig(package_name="foo", source_files=["foo"])
 
         assert config.path is None
         assert config.values == {}
@@ -51,7 +51,7 @@ class TestSourceFiles:
         """Unrecognised source file extensions are handled."""
         source_path = create_tmp_file(filename="foo.txt")
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=["foo.txt"],
             starting_path=source_path,
         )
@@ -64,7 +64,7 @@ class TestSourceFiles:
         source_path = create_toml(filename="another.toml", content={"bar": "baz"})
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=source_path,
             source_files=["another.toml"],
         )
@@ -85,7 +85,7 @@ class TestSourceFiles:
         )
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=source_path_2,
             source_files=["another.toml", "pyproject.toml"],
         )
@@ -98,7 +98,7 @@ class TestSourceFiles:
         path = create_tmp_file(filename="acme.ini")
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=[str(path)],
         )
 
@@ -112,7 +112,7 @@ class TestSourceFiles:
         pyproject_path = create_pyproject_toml()
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=["~/.config/acme.ini", "pyproject.toml"],
             starting_path=pyproject_path,
         )
@@ -133,7 +133,7 @@ option_2 = value_2
         """
         source_path = create_tmp_file(content=ini_file, filename="foo.ini")
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=source_path,
             source_files=["foo.ini"],
         )
@@ -149,7 +149,7 @@ class TestValidation:
     """Tests for schema validation."""
 
     def test_no_schema(self) -> None:
-        config = UserConfig(project_name="acme", starting_path=Path("/"))
+        config = UserConfig(package_name="acme", starting_path=Path("/"))
 
         assert config.values == {}
 
@@ -169,7 +169,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml()
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
             schema=Schema,
         )
@@ -191,7 +191,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml()
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
         )
 
@@ -213,7 +213,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml(content={"bar": 1})
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
             schema=Schema,
         )
@@ -237,7 +237,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml(content={"bar": 1})
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
             schema=Schema,
         )
@@ -265,7 +265,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml(content={"baz": "baz"})
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
             schema=InitSchema,
         )
@@ -287,7 +287,7 @@ class TestValidation:
 
         pyproject_path = create_pyproject_toml(content={"baz": "baz"})
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             starting_path=pyproject_path,
             schema=Schema,
         )
@@ -301,7 +301,7 @@ class TestValidation:
         class Schema(BaseModel):
             """Defines schema."""
 
-        config = UserConfig(project_name="foo")
+        config = UserConfig(package_name="foo")
 
         assert config.schema is None
 
@@ -329,7 +329,7 @@ option_2 = true
         pyproject_path = create_pyproject_toml(content={"option_3": True})
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,
@@ -359,7 +359,7 @@ option_2 = true
         pyproject_path = create_pyproject_toml(content={"option": "config_3"})
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,
@@ -386,7 +386,7 @@ option_2 = true
         )
 
         config = UserConfig(
-            project_name="foo",
+            package_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,220 +4,126 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+from pydantic import BaseModel
 from pydantic import ValidationError
 
-from maison.config import ProjectConfig
+from maison.config import UserConfig
 from maison.errors import NoSchemaError
-from maison.schema import ConfigSchema
 
 
-class TestProjectConfig:
-    """Tests for the `ProjectConfig` class."""
+class TestUserConfig:
+    """Tests for the `UserConfig` class."""
 
-    def test_repr(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given an instance of `ProjectConfig`,
-        When the string representation is retrieved,
-        Then a useful representation is returned
-        """
+    def test_str(self, create_tmp_file: Callable[..., Path]) -> None:
         pyproject_path = create_tmp_file(filename="pyproject.toml")
 
-        config = ProjectConfig(project_name="foo", starting_path=pyproject_path)
+        config = UserConfig(project_name="foo", starting_path=pyproject_path)
 
-        assert str(config) == "<class 'ProjectConfig'>"
-
-    def test_to_dict(self, create_pyproject_toml: Callable[..., Path]) -> None:
-        """
-        Given an instance of `ProjectConfig`,
-        When the `to_dict` method is invoked,
-        Then a dictionary of all config options is returned
-        """
-        pyproject_path = create_pyproject_toml()
-
-        config = ProjectConfig(project_name="foo", starting_path=pyproject_path)
-
-        assert config.to_dict() == {"bar": "baz"}
+        assert str(config) == "<class 'UserConfig'>"
 
 
-class TestGetOption:
-    """Tests for the `get_option` method."""
+class TestDictObject:
+    """Tests to ensure that the config is accessible as a dict."""
 
     def test_valid_pyproject(self, create_pyproject_toml: Callable[..., Path]) -> None:
-        """
-        Given a valid `pyproject.toml`,
-        When the `ProjectConfig` class is instantiated,
-        Then a config value can be retrieved
-        """
+        """A valid pyproject is parsed to a dict object."""
         pyproject_path = create_pyproject_toml()
-        config = ProjectConfig(project_name="foo", starting_path=pyproject_path)
 
-        result = config.get_option("bar")
+        config = UserConfig(project_name="foo", starting_path=pyproject_path)
 
-        assert result == "baz"
-
-    def test_no_pyproject(self) -> None:
-        """
-        Given no supplied `pyproject.toml`,
-        When the `ProjectConfig` class is instantiated,
-        Then the situation is handled gracefully
-        """
-        config = ProjectConfig(project_name="foo", starting_path=Path("/"))
-
-        result = config.get_option("bar")
-
-        assert result is None
-
-    def test_default(self) -> None:
-        """
-        Given a `ProjectConfig` object,
-        When a missing option is retrieved with a given default,
-        Then the default is returned
-        """
-        config = ProjectConfig(project_name="foo", starting_path=Path("/"))
-
-        result = config.get_option("bar", "baz")
-
-        assert result == "baz"
-
-    def test_valid_pyproject_with_no_project_section(
-        self, create_toml: Callable[..., Path]
-    ) -> None:
-        """
-        Given a valid `pyproject.toml` without a [tool.{project_name}] section,
-        When the `ProjectConfig` class is instantiated,
-        Then a config value can be retrieved
-        """
-        pyproject_path = create_toml(filename="pyproject.toml", content={"foo": "bar"})
-        config = ProjectConfig(project_name="baz", starting_path=pyproject_path)
-
-        result = config.get_option("foo")
-
-        assert result is None
+        assert config.values == {"bar": "baz"}
 
 
 class TestSourceFiles:
     """Tests for the `source_files` init argument."""
 
     def test_not_found(self) -> None:
-        """
-        Given a source filename which doesn't exist,
-        When the `ProjectConfig` is instantiated with the source,
-        Then the config dict is empty
-        """
-        config = ProjectConfig(project_name="foo", source_files=["foo"])
+        """Non existent source files are handled."""
+        config = UserConfig(project_name="foo", source_files=["foo"])
 
-        assert config.config_path is None
-        assert config.to_dict() == {}
+        assert config.path is None
+        assert config.values == {}
 
     def test_unrecognised_file_extension(
         self,
         create_tmp_file: Callable[..., Path],
     ) -> None:
-        """
-        Given a source with a file extension that isn't recognised,
-        When the `ProjectConfig` is instantiated with the source,
-        Then the config dict is empty
-        """
+        """Unrecognised source file extensions are handled."""
         source_path = create_tmp_file(filename="foo.txt")
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=["foo.txt"],
             starting_path=source_path,
         )
 
-        assert config.discovered_config_paths == []
-        assert config.to_dict() == {}
+        assert config.path is None
+        assert config.values == {}
 
     def test_single_valid_toml_source(self, create_toml: Callable[..., Path]) -> None:
-        """
-        Given a `toml` source file other than `pyproject.toml`,
-        When the `ProjectConfig` is instantiated with the source,
-        Then the source is retrieved correctly
-        """
+        """Toml files other than pyproject.toml files are handled."""
         source_path = create_toml(filename="another.toml", content={"bar": "baz"})
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=source_path,
             source_files=["another.toml"],
         )
 
-        result = config.get_option("bar")
-
-        assert config.config_path == source_path
-        assert result == "baz"
+        assert config.path == source_path
+        assert config.values["bar"] == "baz"
 
     def test_multiple_valid_toml_sources(
         self,
         create_pyproject_toml: Callable[..., Path],
         create_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given multiple `toml` source files,
-        When the `ProjectConfig` is instantiated with the sources,
-        Then first source to be found is retrieved correctly
-        """
+        """When there are multiple sources, the first one is used"""
         source_path_1 = create_toml(filename="another.toml", content={"bar": "baz"})
 
         source_path_2 = create_pyproject_toml(
             section_name="oof", content={"rab": "zab"}
         )
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=source_path_2,
             source_files=["another.toml", "pyproject.toml"],
         )
 
-        result = config.get_option("bar")
-
-        assert config.discovered_config_paths == [source_path_1, source_path_2]
-        assert result == "baz"
+        assert config.discovered_paths == [source_path_1, source_path_2]
+        assert config.values["bar"] == "baz"
 
     def test_absolute_path(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a source file with an absolute path to an existing config,
-        When the `ProjectConfig` is instantiated with the source,
-        Then the source is successfully retrieved
-        """
+        """Source files can be found using absolute paths"""
         path = create_tmp_file(filename="acme.ini")
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=[str(path)],
         )
 
-        assert config.discovered_config_paths == [path]
+        assert config.discovered_paths == [path]
 
     def test_absolute_path_not_exist(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given a source file with an absolute path to an non-existing config,
-        When the `ProjectConfig` is instantiated with the source,
-        Then the missing source is ignored
-        """
+        """Non existent absolute paths are handled."""
         pyproject_path = create_pyproject_toml()
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=["~/.config/acme.ini", "pyproject.toml"],
             starting_path=pyproject_path,
         )
 
-        assert config.discovered_config_paths == [pyproject_path]
+        assert config.discovered_paths == [pyproject_path]
 
 
 class TestIniFiles:
     """Tests for handling x.ini config files."""
 
     def test_valid_ini_file(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a valid .ini file as a source,
-        When the `ProjectConfig` is instantiated with the sources,
-        Then the .ini file is parsed and the config dict is populated
-        """
         ini_file = """
 [section 1]
 option_1 = value_1
@@ -226,14 +132,14 @@ option_1 = value_1
 option_2 = value_2
         """
         source_path = create_tmp_file(content=ini_file, filename="foo.ini")
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=source_path,
             source_files=["foo.ini"],
         )
 
-        assert config.discovered_config_paths == [source_path]
-        assert config.to_dict() == {
+        assert config.discovered_paths == [source_path]
+        assert config.values == {
             "section 1": {"option_1": "value_1"},
             "section 2": {"option_2": "value_2"},
         }
@@ -243,14 +149,9 @@ class TestValidation:
     """Tests for schema validation."""
 
     def test_no_schema(self) -> None:
-        """
-        Given an instance of `ProjectConfig` with no schema,
-        When the `validate` method is called,
-        Then a `NoSchemaError` is raised
-        """
-        config = ProjectConfig(project_name="acme", starting_path=Path("/"))
+        config = UserConfig(project_name="acme", starting_path=Path("/"))
 
-        assert config.to_dict() == {}
+        assert config.values == {}
 
         with pytest.raises(NoSchemaError):
             config.validate()
@@ -259,183 +160,154 @@ class TestValidation:
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given an instance of `ProjectConfig` with a given schema,
-        When the `validate` method is called,
-        Then the configuration is validated
-        """
+        """The config is validated with a given schema."""
 
-        class Schema(ConfigSchema):
+        class Schema(BaseModel):
             """Defines schema."""
 
             bar: str
 
         pyproject_path = create_pyproject_toml()
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
-            config_schema=Schema,
+            schema=Schema,
         )
 
         config.validate()
 
-        assert config.get_option("bar") == "baz"
+        assert config.values["bar"] == "baz"
 
     def test_one_schema_injected_at_validation(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given an instance of `ProjectConfig` with a given schema,
-        When the `validate` method is called,
-        Then the configuration is validated
-        """
+        """Schemas supplied as an argument are used"""
 
-        class Schema(ConfigSchema):
+        class Schema(BaseModel):
             """Defines schema."""
 
             bar: str
 
         pyproject_path = create_pyproject_toml()
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
         )
 
-        config.validate(config_schema=Schema)
+        config.validate(schema=Schema)
 
-        assert config.get_option("bar") == "baz"
+        assert config.values["bar"] == "baz"
 
     def test_use_schema_values(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given an instance of `ProjectConfig` with a given schema,
-        When the `validate` method is called,
-        Then the configuration is validated and values are cast to those in the schema
-            and default values are used
-        """
+        """Config values can be cast to the validated values."""
 
-        class Schema(ConfigSchema, coerce_numbers_to_str=True):
+        class Schema(BaseModel, coerce_numbers_to_str=True):
             """Defines schema."""
 
             bar: str
             other: str = "hello"
 
         pyproject_path = create_pyproject_toml(content={"bar": 1})
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
-            config_schema=Schema,
+            schema=Schema,
         )
 
         config.validate()
 
-        assert config.get_option("bar") == "1"
-        assert config.get_option("other") == "hello"
+        assert config.values["bar"] == "1"
+        assert config.values["other"] == "hello"
 
     def test_not_use_schema_values(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given an instance of `ProjectConfig` with a given schema,
-        When the `validate` method is called with `use_schema_values` set to `False`,
-        Then the configuration is validated but values remain as in the config
-        """
+        """If `use_schema_values` is set to False then don't use validated values."""
 
-        class Schema(ConfigSchema, coerce_numbers_to_str=True):
+        class Schema(BaseModel, coerce_numbers_to_str=True):
             """Defines schema."""
 
             bar: str
             other: str = "hello"
 
         pyproject_path = create_pyproject_toml(content={"bar": 1})
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
-            config_schema=Schema,
+            schema=Schema,
         )
 
         config.validate(use_schema_values=False)
 
-        assert config.get_option("bar") == 1
-        assert config.get_option("other") is None
+        assert config.values["bar"] == 1
+        assert "other" not in config.values
 
     def test_schema_override(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given an instance of `ProjectConfig` with a given schema,
-        When the `validate` method is called with a new schema,
-        Then the new schema is used
-        """
+        """Schemas given as an argument are preferred"""
 
-        class Schema1(ConfigSchema):
+        class InitSchema(BaseModel):
             """Defines schema for 1."""
 
             bar: str = "schema_1"
 
-        class Schema2(ConfigSchema):
+        class ArgumentSchema(BaseModel):
             """Defines schema for 2."""
 
             bar: str = "schema_2"
 
         pyproject_path = create_pyproject_toml(content={"baz": "baz"})
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
-            config_schema=Schema1,
+            schema=InitSchema,
         )
 
-        config.validate(config_schema=Schema2)
+        config.validate(schema=ArgumentSchema)
 
-        assert config.get_option("bar") == "schema_2"
+        assert config.values["bar"] == "schema_2"
 
     def test_invalid_configuration(
         self,
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given a configuration which doesn't conform to the schema,
-        When the `validate` method is called,
-        Then an error is raised
-        """
+        """Validation errors are raised when config fails validation."""
 
-        class Schema(ConfigSchema):
+        class Schema(BaseModel):
             """Defines schema."""
 
             bar: str
 
         pyproject_path = create_pyproject_toml(content={"baz": "baz"})
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             starting_path=pyproject_path,
-            config_schema=Schema,
+            schema=Schema,
         )
 
         with pytest.raises(ValidationError):
             config.validate()
 
     def test_setter(self) -> None:
-        """
-        Given an instance of `ProjectConfig`,
-        When the `config_schema` is set,
-        Then the `config_schema` can be retrieved
-        """
+        """Schemas can be set using the setter."""
 
-        class Schema(ConfigSchema):
+        class Schema(BaseModel):
             """Defines schema."""
 
-        config = ProjectConfig(project_name="foo")
+        config = UserConfig(project_name="foo")
 
-        assert config.config_schema is None
+        assert config.schema is None
 
-        config.config_schema = Schema
+        config.schema = Schema
 
-        assert config.config_schema is Schema
+        assert config.schema is Schema
 
 
 class TestMergeConfig:
@@ -447,11 +319,7 @@ class TestMergeConfig:
         create_tmp_file: Callable[..., Path],
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given multiple existing config sources with no overlapping options,
-        When the `merge_configs` boolean is set to `True`,
-        Then the configs are merged
-        """
+        """Configs without overlapping values are merged."""
         config_1_path = create_toml(filename="config.toml", content={"option_1": True})
         ini_file = """
 [foo]
@@ -460,15 +328,15 @@ option_2 = true
         config_2_path = create_tmp_file(filename="config.ini", content=ini_file)
         pyproject_path = create_pyproject_toml(content={"option_3": True})
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,
         )
 
-        assert config.config_path == [config_1_path, config_2_path, pyproject_path]
-        assert config.to_dict() == {
+        assert config.path == [config_1_path, config_2_path, pyproject_path]
+        assert config.values == {
             "option_1": True,
             "foo": {
                 "option_2": "true",
@@ -481,11 +349,7 @@ option_2 = true
         create_toml: Callable[..., Path],
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given multiple existing config sources with overlapping options,
-        When the `merge_configs` boolean is set to `True`,
-        Then the configs are merged from right to left
-        """
+        """Configs with overlapping values are merged."""
         config_1_path = create_toml(
             filename="config_1.toml", content={"option": "config_1"}
         )
@@ -494,14 +358,14 @@ option_2 = true
         )
         pyproject_path = create_pyproject_toml(content={"option": "config_3"})
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,
         )
 
-        assert config.to_dict() == {
+        assert config.values == {
             "option": "config_3",
         }
 
@@ -510,11 +374,7 @@ option_2 = true
         create_toml: Callable[..., Path],
         create_pyproject_toml: Callable[..., Path],
     ) -> None:
-        """
-        Given multiple existing config sources with overlapping options,
-        When the `merge_configs` boolean is set to `True`,
-        Then the configs are merged from right to left
-        """
+        """Configs with nested overlapping values are deep merged."""
         config_1_path = create_toml(
             filename="config_1.toml", content={"option": {"nested_1": "config_1"}}
         )
@@ -525,13 +385,13 @@ option_2 = true
             content={"option": {"nested_2": "config_3"}}
         )
 
-        config = ProjectConfig(
+        config = UserConfig(
             project_name="foo",
             source_files=[str(config_1_path), str(config_2_path), "pyproject.toml"],
             starting_path=pyproject_path,
             merge_configs=True,
         )
 
-        assert config.to_dict() == {
+        assert config.values == {
             "option": {"nested_1": "config_1", "nested_2": "config_3"},
         }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for the `utils` module."""
 
 from pathlib import Path
-from typing import Any
 from typing import Callable
 from typing import Dict
 from unittest.mock import MagicMock
@@ -18,11 +17,7 @@ class TestContainsFile:
     """Tests for the `contains_file` function"""
 
     def test_found(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a path containing a file,
-        When the `path_contains_file` function is invoked with the path and filename,
-        Then a `True` is returned
-        """
+        """Return `True` if the path contains the file"""
         path = create_tmp_file(filename="file.txt")
 
         result = path_contains_file(path=path.parent, filename="file.txt")
@@ -30,11 +25,7 @@ class TestContainsFile:
         assert result is True
 
     def test_not_found(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a path not containing a file,
-        When the `path_contains_file` function is invoked with the path and filename,
-        Then a `False` is returned
-        """
+        """Return `False` if the path does not contain the file"""
         path = create_tmp_file(filename="file.txt")
 
         result = path_contains_file(path=path.parent, filename="other.txt")
@@ -49,11 +40,7 @@ class TestGetFilePath:
     def test_in_current_directory(
         self, mock_path: MagicMock, create_tmp_file: Callable[..., Path]
     ) -> None:
-        """
-        Given a file in the `cwd`,
-        When the `get_file_path` function is invoked without a `starting_path`,
-        Then the path to the file is returned
-        """
+        """The path to a file is returned."""
         mock_path.return_value.expanduser.return_value.is_absolute.return_value = False
 
         path_to_file = create_tmp_file(filename="file.txt")
@@ -64,11 +51,7 @@ class TestGetFilePath:
         assert result == path_to_file
 
     def test_in_parent_directory(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a file in the parent of `cwd`,
-        When the `get_file_path` function is invoked,
-        Then the path to the file is returned
-        """
+        """The path to a file in a parent directory is returned."""
         path_to_file = create_tmp_file(filename="file.txt")
         sub_dir = path_to_file / "sub"
 
@@ -77,21 +60,13 @@ class TestGetFilePath:
         assert result == path_to_file
 
     def test_not_found(self) -> None:
-        """
-        Given no in the `cwd` or parent dirs,
-        When the `get_file_path` function is invoked,
-        Then `None` is returned
-        """
+        """If the file isn't found in the tree then return a `None`"""
         result = get_file_path(filename="file.txt", starting_path=Path("/nowhere"))
 
         assert result is None
 
     def test_with_given_path(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given a file in a path,
-        When the `get_file_path` function is invoked with a `starting_path`,
-        Then the path to the file is returned
-        """
+        """A `starting_path` can be used to initiate the starting search directory"""
         path_to_file = create_tmp_file(filename="file.txt")
 
         result = get_file_path(filename="file.txt", starting_path=path_to_file)
@@ -99,11 +74,7 @@ class TestGetFilePath:
         assert result == path_to_file
 
     def test_absolute_path(self, create_tmp_file: Callable[..., Path]) -> None:
-        """
-        Given an absolute path to an existing file,
-        When the `get_file_path` function is invoked with the filename,
-        Then the path to the file is returned
-        """
+        """An absolute path to an existing file is returned"""
         path_to_file = create_tmp_file(filename="file.txt")
 
         result = get_file_path(filename=str(path_to_file))
@@ -111,11 +82,7 @@ class TestGetFilePath:
         assert result == path_to_file
 
     def test_absolute_path_not_exist(self) -> None:
-        """
-        Given an absolute path to an non-existing file,
-        When the `get_file_path` function is invoked with the filename,
-        Then None is returned
-        """
+        """If the absolute path doesn't exist return a `None`"""
         result = get_file_path(filename="~/xxxx/yyyy/doesnotexist.xyz")
 
         assert result is None
@@ -143,24 +110,15 @@ class TestDeepMerge:
     )
     def test_success(
         self,
-        a: Dict[Any, Any],
-        b: Dict[Any, Any],
-        expected: Dict[Any, Any],
+        a: Dict[int, int],
+        b: Dict[int, int],
+        expected: Dict[int, int],
     ) -> None:
-        """
-        Given two dictionaries `a` and `b`,
-        When the `deep_merge` function is invoked with `a` and `b` as arguments,
-        Then the returned value is as expected
-        """
         assert deep_merge(a, b) == expected
         assert a == expected
 
     def test_incompatible_dicts(self) -> None:
-        """
-        Given two incompatible dictionaries `a` and `b`,
-        When the `deep_merge` function is invoked with `a` and `b` as arguments,
-        Then a RuntimeError is raised
-        """
+        """Trying to merge incompatible dicts returns an error"""
         dict_a = {1: 2, 2: 5}
         dict_b = {1: {3: 4}}
 


### PR DESCRIPTION
This PR introduces some breaking changes.

### Renaming `ProjectConfig` to `UserConfig`

The new name better reflects what the object represents, the user's configuration.

The renaming also includes some other changes to the API:
* The config values are now accessed through `UserConfig().values`.
* The `project_name` has been renamed to `package_name` to better reflect that it refers to the configuration of the package, not the user's project.

### Removing `pydantic` as a dependency

Previously this was a dependency of `maison`. This meant that any installs of `maison` will also install `pydantic`, but `pydantic` was only used for an optional part of this package (validation). The use of `pydantic` to perform validation against a schema is still preferred, but it's now up to the user to include this dependency. 

### Dropping 3.8 support

This was done in #311 