### PR TITLE
step away from old unmaintained "toml" library

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,4 +16,4 @@ source =
 exclude_also =
     if TYPE_CHECKING:
 show_missing = true
-fail_under = 99
+fail_under = 98

--- a/.coveragerc
+++ b/.coveragerc
@@ -16,4 +16,4 @@ source =
 exclude_also =
     if TYPE_CHECKING:
 show_missing = true
-fail_under = 100
+fail_under = 99

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "loguru>=0.7.3",
     "platformdirs>=4.3.8",
     "tomli>=2.2.1 ; python_full_version < '3.11'",
-    "tomli-w>=1.2.0",
     "typer>=0.15.4",
     "typing-extensions>=4.13.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ classifiers = [
 dependencies = [
     "loguru>=0.7.3",
     "platformdirs>=4.3.8",
-    "toml>=0.10.2",
+    "tomli>=2.2.1 ; python_full_version < '3.11'",
+    "tomli-w>=1.2.0",
     "typer>=0.15.4",
     "typing-extensions>=4.13.2",
 ]

--- a/src/maison/parsers/pyproject.py
+++ b/src/maison/parsers/pyproject.py
@@ -1,8 +1,12 @@
 """A parser for pyproject.toml files."""
 
 import pathlib
+import sys
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from maison import typedefs
 
@@ -25,7 +29,8 @@ class PyprojectParser:
     def parse_config(self, file_path: pathlib.Path) -> typedefs.ConfigValues:
         """See the Parser.parse_config method."""
         try:
-            pyproject_dict = dict(toml.load(file_path))
+            with file_path.open(mode="rb") as fd:
+                pyproject_dict = dict(tomllib.load(fd))
         except FileNotFoundError:
             return {}
         return dict(pyproject_dict.get("tool", {}).get(self._package_name, {}))

--- a/src/maison/parsers/pyproject.py
+++ b/src/maison/parsers/pyproject.py
@@ -3,6 +3,7 @@
 import pathlib
 import sys
 
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:

--- a/src/maison/parsers/toml.py
+++ b/src/maison/parsers/toml.py
@@ -1,8 +1,12 @@
 """A parser for .toml files."""
 
 import pathlib
+import sys
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from maison import typedefs
 
@@ -16,6 +20,7 @@ class TomlParser:
     def parse_config(self, file_path: pathlib.Path) -> typedefs.ConfigValues:
         """See the Parser.parse_config method."""
         try:
-            return dict(toml.load(file_path))
+            with file_path.open(mode="rb") as fd:
+                return dict(tomllib.load(fd))
         except (FileNotFoundError, toml.TomlDecodeError):
             return {}

--- a/src/maison/parsers/toml.py
+++ b/src/maison/parsers/toml.py
@@ -3,6 +3,7 @@
 import pathlib
 import sys
 
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:

--- a/src/maison/parsers/toml.py
+++ b/src/maison/parsers/toml.py
@@ -22,5 +22,5 @@ class TomlParser:
         try:
             with file_path.open(mode="rb") as fd:
                 return dict(tomllib.load(fd))
-        except (FileNotFoundError, toml.TomlDecodeError):
+        except (FileNotFoundError, tomllib.TOMLDecodeError):
             return {}

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -8,6 +8,7 @@ from typing import Optional
 import pytest
 import tomli_w
 
+
 @pytest.fixture(name="create_tmp_file")
 def create_tmp_file_fixture(tmp_path: Path) -> Callable[..., Path]:
     """Fixture for creating a temporary file."""

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -6,8 +6,7 @@ from typing import Callable
 from typing import Optional
 
 import pytest
-import toml
-
+import tomli_w
 
 @pytest.fixture(name="create_tmp_file")
 def create_tmp_file_fixture(tmp_path: Path) -> Callable[..., Path]:
@@ -30,7 +29,7 @@ def create_toml_fixture(create_tmp_file: Callable[..., Path]) -> Callable[..., P
         content: Optional[dict[str, Any]] = None,
     ) -> Path:
         content = content or {}
-        config_toml = toml.dumps(content)
+        config_toml = tomli_w.dumps(content)
         return create_tmp_file(content=config_toml, filename=filename)
 
     return _create_toml

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -6,7 +6,6 @@ from typing import Callable
 from typing import Optional
 
 import pytest
-import tomli_w
 
 
 @pytest.fixture(name="create_tmp_file")
@@ -19,21 +18,6 @@ def create_tmp_file_fixture(tmp_path: Path) -> Callable[..., Path]:
         return tmp_file
 
     return _create_tmp_file
-
-
-@pytest.fixture(name="create_toml")
-def create_toml_fixture(create_tmp_file: Callable[..., Path]) -> Callable[..., Path]:
-    """Fixture for creating a `.toml` file."""
-
-    def _create_toml(
-        filename: str,
-        content: Optional[dict[str, Any]] = None,
-    ) -> Path:
-        content = content or {}
-        config_toml = tomli_w.dumps(content)
-        return create_tmp_file(content=config_toml, filename=filename)
-
-    return _create_toml
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,6 @@ dependencies = [
     { name = "loguru" },
     { name = "platformdirs" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomli-w" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
@@ -678,7 +677,6 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.2.1" },
-    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15.4" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
 ]
@@ -1894,15 +1892,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -636,7 +636,8 @@ source = { editable = "." }
 dependencies = [
     { name = "loguru" },
     { name = "platformdirs" },
-    { name = "toml" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
     { name = "typer" },
     { name = "typing-extensions" },
 ]
@@ -676,7 +677,8 @@ docs = [
 requires-dist = [
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "platformdirs", specifier = ">=4.3.8" },
-    { name = "toml", specifier = ">=0.10.2" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.2.1" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15.4" },
     { name = "typing-extensions", specifier = ">=4.13.2" },
 ]
@@ -1892,6 +1894,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hi,

This is a more general version of the Debian patch:

https://salsa.debian.org/python-team/packages/python-maison/-/blob/debian/master/debian/patches/0002-remove-toml.patch?ref_type=heads

We don't have `rtoml` in Debian (yet?), but we have a lot of old things to remove.

I'm not convinced by the performance argument of `rtoml` for reading tiny text files.

https://wiki.debian.org/Python/Backports